### PR TITLE
Fix setup command test list

### DIFF
--- a/src/dashboard/parser.ts
+++ b/src/dashboard/parser.ts
@@ -65,8 +65,9 @@ export class SpecParser {
   private steeringLoader: SteeringLoader;
 
   constructor(projectPath: string) {
-    // Normalize and resolve the project path to handle different path formats
-    this.projectPath = normalize(resolve(projectPath));
+    // Normalize path to handle Windows/Unix separators before resolving
+    const normalizedInput = projectPath.replace(/\\/g, '/');
+    this.projectPath = normalize(resolve(normalizedInput));
     this.specsPath = join(this.projectPath, '.claude', 'specs');
     this.steeringLoader = new SteeringLoader(this.projectPath);
   }

--- a/src/steering.ts
+++ b/src/steering.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { join, normalize } from 'path';
 
 export interface SteeringDocuments {
   product?: string;
@@ -11,7 +11,8 @@ export class SteeringLoader {
   private steeringDir: string;
 
   constructor(projectRoot: string = process.cwd()) {
-    this.steeringDir = join(projectRoot, '.claude', 'steering');
+    const root = normalize(projectRoot.replace(/\\/g, '/'));
+    this.steeringDir = join(root, '.claude', 'steering');
   }
 
   async loadSteeringDocuments(): Promise<SteeringDocuments> {

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -47,13 +47,15 @@ describe('SpecWorkflowSetup', () => {
     const commandsDir = join(tempDir, '.claude', 'commands');
     const expectedCommands = [
       'spec-create.md',
-      'spec-requirements.md',
-      'spec-design.md',
-      'spec-tasks.md',
       'spec-execute.md',
       'spec-status.md',
       'spec-list.md',
-      'spec-steering-setup.md'
+      'spec-steering-setup.md',
+      'bug-create.md',
+      'bug-analyze.md',
+      'bug-fix.md',
+      'bug-verify.md',
+      'bug-status.md'
     ];
 
     for (const command of expectedCommands) {
@@ -62,7 +64,11 @@ describe('SpecWorkflowSetup', () => {
 
       const content = await fs.readFile(commandPath, 'utf-8');
       expect(content.length).toBeGreaterThan(0);
-      expect(content).toContain('# Spec');
+      if (command.startsWith('spec-')) {
+        expect(content).toContain('# Spec');
+      } else if (command.startsWith('bug-')) {
+        expect(content).toContain('# Bug');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- update slash command list in setup tests
- handle backslash paths in parser and steering loader
- adjust content checks for spec vs bug commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688a1f723b48832586114ef5b28863fd