### PR TITLE
Fix docs and tests for updated command set

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ npx claude-spec-setup
 
 ## 🎯 What It Does
 
-The setup automatically creates:
+- The setup automatically creates:
 - **📁 .claude/ directory structure** with all necessary files
-- **📝 13 slash commands** (8 spec workflow + 5 bug fix workflow)
+- **📝 10 slash commands** (5 spec workflow + 5 bug fix workflow)
 - **🎯 Steering documents** for persistent project context
 - **🤖 Auto-generated task commands** for each spec
 - **📋 Document templates** for both workflows
@@ -192,7 +192,13 @@ After setup, use these commands in Claude Code:
 
 ### 🆕 Auto-Generated Task Commands
 
-The workflow now automatically creates individual commands for each task:
+During `/spec-create` you will be asked if you want task commands generated. If
+you answer **yes**, Claude Code automatically runs
+`npx @pimzino/claude-code-spec-workflow@latest generate-task-commands <spec-name>`
+to create commands for each approved task. You can also run this command
+yourself later.
+
+Benefits of task commands:
 - **Easier execution**: `/user-auth-task-1` instead of `/spec-execute 1 user-authentication`
 - **Better organization**: Commands grouped by spec in `.claude/commands/{spec-name}/`
 - **Auto-completion**: Claude Code can suggest spec-specific commands

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,7 @@ program
         console.log();
         console.log(chalk.cyan('This will create:'));
         console.log(chalk.gray('  📁 .claude/ directory structure'));
-        console.log(chalk.gray('  📝 13 slash commands (8 spec workflow + 5 bug fix workflow)'));
+        console.log(chalk.gray('  📝 10 slash commands (5 spec workflow + 5 bug fix workflow)'));
         console.log(chalk.gray('  🤖 Auto-generated task commands'));
         console.log(chalk.gray('  📋 Document templates'));
         console.log(chalk.gray('  🔧 NPX-based task command generation'));
@@ -118,9 +118,6 @@ program
       console.log(chalk.cyan('Available commands:'));
       console.log(chalk.white.bold('📊 Spec Workflow (for new features):'));
       console.log(chalk.gray('  /spec-create <feature-name>  - Create a new spec'));
-      console.log(chalk.gray('  /spec-requirements           - Generate requirements'));
-      console.log(chalk.gray('  /spec-design                 - Generate design'));
-      console.log(chalk.gray('  /spec-tasks                  - Generate tasks'));
       console.log(chalk.gray('  /spec-execute <task-id>      - Execute tasks'));
       console.log(chalk.gray('  /{spec-name}-task-{id}       - Auto-generated task commands'));
       console.log(chalk.gray('  /spec-status                 - Show status'));

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -47,13 +47,15 @@ describe('SpecWorkflowSetup', () => {
     const commandsDir = join(tempDir, '.claude', 'commands');
     const expectedCommands = [
       'spec-create.md',
-      'spec-requirements.md',
-      'spec-design.md',
-      'spec-tasks.md',
       'spec-execute.md',
       'spec-status.md',
       'spec-list.md',
-      'spec-steering-setup.md'
+      'spec-steering-setup.md',
+      'bug-create.md',
+      'bug-analyze.md',
+      'bug-fix.md',
+      'bug-verify.md',
+      'bug-status.md'
     ];
 
     for (const command of expectedCommands) {


### PR DESCRIPTION
## Summary
- correct number of generated slash commands
- explain that task command generation is automatic when approved
- update CLI output to match available commands
- update tests for current command set

## Testing
- `npm test` *(fails: SpecParser Path Normalization & SteeringLoader)*

------
https://chatgpt.com/codex/tasks/task_b_688a1cb1ed708325ae19db87c74d6bbe