### PR TITLE
fix: improve bug status determination to prevent premature 'verifying' state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pimzino/claude-code-spec-workflow",
-  "version": "1.4.8",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pimzino/claude-code-spec-workflow",
-      "version": "1.4.8",
+      "version": "1.5.5",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^7.0.4",


### PR DESCRIPTION
## Summary

This PR fixes an issue where bugs in the dashboard would incorrectly show as "verifying" when they're actually still in earlier stages of the workflow (e.g., "reported" or "analyzing").

## Problem

The dashboard was checking only for the existence of `verification.md` files rather than their content. Since the bug workflow creates template files upfront, bugs with empty template content were incorrectly showing as "verifying" status.

## Solution

- Added a new `fixed` status to properly track when a fix has been implemented
- Added content validation to ensure files have meaningful content, not just template placeholders
- Only show "verifying" status when:
  1. The fix has been implemented (status is 'fixed')
  2. The verification file has actual test results or regression checks
- Added `hasContentAfterSection` helper method to detect real content vs templates

## Changes

1. **Bug Status Flow**: `reported` → `analyzing` → `fixing` → `fixed` → `verifying` → `resolved`
2. **Content Validation**: Check for actual content in sections, skipping template placeholders
3. **Fix Tracking**: Added support for `fix.md` file to distinguish between "fixing" (in progress) and "fixed" (complete)

## Testing

Tested with a real bug workflow where:
- `analysis.md` and `verification.md` contained only template content
- Dashboard now correctly shows "reported" status instead of "verifying"
- When content is added to files, status progresses correctly through the workflow

## Impact

This ensures the dashboard accurately reflects the current state of bug workflows, preventing confusion about which stage a bug is actually in.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>