### PR TITLE
fix: remove incorrect backticks in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Transform your development with structured workflows: **Requirements → Design 
 
 1. Install the workflow globally
 ```bash
- `npm i -g @pimzino/claude-code-spec-workflow`
+npm i -g @pimzino/claude-code-spec-workflow
 ```
 2. Run the setup command in your project directory
 ```bash


### PR DESCRIPTION
## Summary
- Fixed markdown rendering issue in the Installation section
- Removed extra backticks around the npm install command

## Changes
The npm install command in the Installation section had incorrect backticks that were causing markdown rendering issues:

**Before:**
```bash
 `npm i -g @pimzino/claude-code-spec-workflow`
```

**After:**
```bash
npm i -g @pimzino/claude-code-spec-workflow
```

## Test plan
- [x] Verified markdown renders correctly in preview
- [x] Confirmed the command can be copied and executed properly

🤖 Generated with [Claude Code](https://claude.ai/code)